### PR TITLE
ci: make renovate bump chart version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:base",
+    ":gitSignOff"
   ],
   "regexManagers": [
     {
@@ -10,6 +11,12 @@
         "# renovate: datasource=(?<datasource>[a-z-]+?) depName=(?<depName>[a-zA-Z0-9-_\\/]+?)(?: versioning=[\"']?(?<versioning>[a-z-0-9]+?)[\"']?)?(?: extractVersion=[\"']?(?<extractVersion>\\^.*?\\$)[\"']?)?\\n.*(?:[:=]\\s|=)[\"']?(?<currentValue>v?[a-zA-Z0-9\\.\\+-:~]+)[\"']?"
       ],
       "versioningTemplate": "{{#if versioning}}{{versioning}}{{else}}semver{{/if}}"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchPaths": ["charts/**"],
+      "bumpVersion": "patch"
     }
   ]
 }


### PR DESCRIPTION
# Pull Request
<!-- Thanks for submitting a pull request! -->

## Description
this makes renovate increment the patch version in a helm chart `version` if a dependency is updated


Issue Number: N/A

## Benefits
<!-- How does this change benefit to anyone? -->
no manual updating of chart version is needed


## Possible Drawbacks
<!-- How could this change have a negative effect on anyone? -->

## Checklist
<!-- Please make sure that all points in the checklist are met before requesting a review. -->

Please check if your PR fulfills the following requirements:

- [x] Title starts with chart name (e.g. `[heist]`) if strictly relevant to a single chart
- [ ] Bumped chart version according to semver if Chart has been changed
- [ ] Changed `artifacthub.io/changes` annotation in the chart's Chart.yaml to reflect your changes if a Chart has been changed
- [x] Commits are compliant with the [**Conventional Commits**](https://www.conventionalcommits.org/en/v1.0.0/) format
- [x] Commits are signed-off. You hereby accept the [**Developer Certificate of Origin**](https://developercertificate.org/)
- [x] Pull request does not include any merge commits (rebase only)
